### PR TITLE
Fixed deprecation warning given by experimentalObjectRestSpread

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,8 +7,8 @@
     },
     "extends": "eslint:recommended",
     "parserOptions": {
+        "ecmaVersion": 2018,
         "ecmaFeatures": {
-            "experimentalObjectRestSpread": true,
             "jsx": true
         },
         "sourceType": "module"


### PR DESCRIPTION
Fixed deprecation warning given by experimentalObjectRestSpread: true replaced with ecmaVersion: 2018